### PR TITLE
redirect invalid questions, flash warning message

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,8 @@
-from flask import Flask, redirect, render_template, request
+from flask import Flask, redirect, render_template, request, flash
 from surveys import satisfaction_survey as satisfy
 
 app = Flask(__name__)
+app.secret_key = "many random chars"
 
 responses = []
 
@@ -12,19 +13,19 @@ def home():
 @app.route("/questions/<number>")
 def question(number):
   index = int(number)
-  if index < len(satisfy.questions):
-    return render_template("question.html", quest = satisfy.questions[index])
+  if len(responses) >= len(satisfy.questions):
+    return redirect("/thanks")
+  elif index != len(responses):
+    flash("You tried to access an invalid question; please complete the survey in order!")
+    return redirect(f"/questions/{len(responses)}")
   else:
-    return redirect("/")
+    return render_template("question.html", quest = satisfy.questions[index])
 
 @app.route("/answer", methods=["POST"])
 def answer():
   responses.append(request.form.get("choice"))
-  if(len(satisfy.questions) > len(responses)):
-    return redirect(f"/questions/{len(responses)}")
-  else:
-    return redirect("/end")
+  return redirect(f"/questions/{len(responses)}")
 
-@app.route("/end")
+@app.route("/thanks")
 def thanks():
   return render_template("thanks.html")

--- a/templates/question.html
+++ b/templates/question.html
@@ -3,6 +3,13 @@
 {% block title %}Survey Question{% endblock %}
 
 {% block content %}
+{% with messages = get_flashed_messages() %}
+  {% if messages %}
+    {% for msg in messages %}
+      <p>{{msg}}</p>
+    {% endfor %}
+  {% endif %}
+{% endwith %}
 <h2>Please answer:</h2>
 <p>{{quest.question}}</p>
 <form action="/answer" method="post">


### PR DESCRIPTION
This branch developed redirecting URLs that were submitted with invalid question numbers - either trying to access questions previously answered, skip ahead in the questions, or access question indices beyond what the survey holds. The page will send a flashed message in these scenarios.